### PR TITLE
Migrate Manifest V2 to Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name" : "__MSG_title__",
   "version": "0.1.6",
   "description": "__MSG_description__",
   "default_locale": "en",
 
-  "browser_action": {
+  "action": {
     "default_popup": "index.html",
     "default_icon": "icons/suite_38.png"
   },


### PR DESCRIPTION
After turning off the Manifest V2 Extension, switch to Manifest V3.
See the link below for details:
https://developer.chrome.com/docs/extensions/develop/migrate/manifest